### PR TITLE
Fix SPI communication with the MAX6675 for thermocouple reading

### DIFF
--- a/tiva/reflow_ctrl/main.c
+++ b/tiva/reflow_ctrl/main.c
@@ -806,8 +806,8 @@ int main(void)
         // Assert CS (active low)
         GPIOPinWrite(GPIO_PORTB_BASE, GPIO_PIN_5, 0);
 
-        // Wait for a short delay (e.g., 1ms) for the MAX6675 to prepare data
-        SysCtlDelay(SysCtlClockGet() / (1000 * 3));
+        // Wait for a short delay (e.g., 23 us) for the MAX6675 to prepare data
+        SysCtlDelay(SysCtlClockGet() / (100000 * 3));
 
         // Sending dummy data to generate clock signals
         SSIDataPut(SSI2_BASE, 0x0000);

--- a/tiva/reflow_ctrl/main.c
+++ b/tiva/reflow_ctrl/main.c
@@ -667,6 +667,9 @@ int main(void)
     // Configure PB5 as a GPIO output for manual CS control
     GPIOPinTypeGPIOOutput(GPIO_PORTB_BASE, GPIO_PIN_5);
 
+    // Enable the pull-up resistor on PB5
+    GPIOPadConfigSet(GPIO_PORTB_BASE, GPIO_PIN_5, GPIO_STRENGTH_2MA, GPIO_PIN_TYPE_STD_WPU);
+
     // Configure the pins for SSI functionality
     GPIOPinTypeSSI(GPIO_PORTB_BASE, GPIO_PIN_4 | GPIO_PIN_6 | GPIO_PIN_7);
 

--- a/tiva/reflow_ctrl/main.c
+++ b/tiva/reflow_ctrl/main.c
@@ -667,8 +667,9 @@ int main(void)
     // Configure PB5 as a GPIO output for manual CS control
     GPIOPinTypeGPIOOutput(GPIO_PORTB_BASE, GPIO_PIN_5);
 
-    // Enable the pull-up resistor on PB5
-    GPIOPadConfigSet(GPIO_PORTB_BASE, GPIO_PIN_5, GPIO_STRENGTH_2MA, GPIO_PIN_TYPE_STD_WPU);
+    // Enable push-pull on PB5
+    // (same as for PF4)
+    GPIOPadConfigSet(GPIO_PORTB_BASE, GPIO_PIN_5, GPIO_STRENGTH_8MA, GPIO_PIN_TYPE_STD);
 
     // Configure the pins for SSI functionality
     GPIOPinTypeSSI(GPIO_PORTB_BASE, GPIO_PIN_4 | GPIO_PIN_6 | GPIO_PIN_7);

--- a/tiva/reflow_ctrl/main.c
+++ b/tiva/reflow_ctrl/main.c
@@ -804,6 +804,13 @@ int main(void)
         // -------------------------------------------------------------------------------------------
         //
 
+
+        // Toggle down and up before actually trying to read the MAX6675
+        GPIOPinWrite(GPIO_PORTB_BASE, GPIO_PIN_5, 0);
+        SysCtlDelay(SysCtlClockGet() / (100000 * 3));
+        GPIOPinWrite(GPIO_PORTB_BASE, GPIO_PIN_5, GPIO_PIN_5);  // <-- This should now really be 3.3V, not 1.0V
+        SysCtlDelay(SysCtlClockGet() / (100000 * 3));
+
         // Read the digital thermocouple MAX6675 (blocking).
         //SSIDataGet(SSI2_BASE, &ui32DigitalThermocoupleData);
         ui32DigitalThermocoupleData = 0;
@@ -823,7 +830,16 @@ int main(void)
 
 //        while (SSIBusy(SSI2_BASE)) {}
 
+        // Wait for a short delay (e.g., 23 us)
+        SysCtlDelay(SysCtlClockGet() / (100000 * 3));
+
         // De-assert CS (inactive high)
+        GPIOPinWrite(GPIO_PORTB_BASE, GPIO_PIN_5, GPIO_PIN_5);
+
+        // Toggle down and up again
+        SysCtlDelay(SysCtlClockGet() / (100000 * 3));
+        GPIOPinWrite(GPIO_PORTB_BASE, GPIO_PIN_5, 0);
+        SysCtlDelay(SysCtlClockGet() / (100000 * 3));
         GPIOPinWrite(GPIO_PORTB_BASE, GPIO_PIN_5, GPIO_PIN_5);
 
         // Hinweis: Das Datenblatt des MAX6675 sagt:


### PR DESCRIPTION
Fixed temperature readings by toggling chip select and configuring the GPIO as push-pull

Note: The temperature errors resulted from bit shifting errors (this is why the read values have often been for instance twice as high as the actual values). The bit shifting errors likely resulted from the chip select value being ca. 1 Volt (instead of 3.3 V) before being pulled to (active) low. I never found out *why* it was 1 Volt. Configuring as weak pull-up or as push-pull helped a bit, but only additional toggling made the error go away. I never measured that it was not 1 V any longer, but the bit reading errors (on which I triggered the scope via SPI value triggering) never occurred, so I did not observe any error any more.